### PR TITLE
ENH: simplified requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 flask
 requests
-datetime


### PR DESCRIPTION
datetime is not a PyPI module, it's part of the core Python implementation, and thus doesn't need to be installed separately :)